### PR TITLE
Fix correctness issues in oracle validation and graph partitioning

### DIFF
--- a/databases/neo4j/generator/schema.py
+++ b/databases/neo4j/generator/schema.py
@@ -64,7 +64,8 @@ class GraphSchema:
 
 
             for i in range(0, edge_num):
-                id0, id1 = random.randint(0, node_num), random.randint(0, node_num)
+                id0 = random.randint(0, node_num - 1)
+                id1 = random.randint(0, node_num - 1)
                 id0 += node_offset
                 id1 += node_offset
                 statement = "MATCH (n0 {id : " + str(id0) + "}), (n1 {id : " + str(id1) + "}) "
@@ -89,4 +90,3 @@ class GraphSchema:
 if __name__ == "__main__":
     G = GraphSchema()
     G.gen()
-

--- a/graphs/kuzu/graph_partitioner.py
+++ b/graphs/kuzu/graph_partitioner.py
@@ -19,7 +19,11 @@ def partition(G : GraphData):
     no_nodes_G2 = G.no_nodes - no_nodes_G1
     
     #Determine the id of nodes in each sub-graphs
-    nodes_id_G1 = np.random.choice(range(0, G.no_nodes), no_nodes_G1)
+    nodes_id_G1 = np.random.choice(
+        range(0, G.no_nodes),
+        no_nodes_G1,
+        replace=False,
+    )
     nodes_id_G2 = []
     for i in range(0, G.no_nodes):
         if i not in nodes_id_G1:
@@ -66,8 +70,8 @@ def partition_2CC(G : GraphData):
             G.nodes.append(node)
         for edge in subG.edges:
             G.edges.append(edge)
-    G.no_nodes = G1.no_nodes + G2.no_edges
-    G.no_edges = G2.no_edges + G2.no_edges
+    G.no_nodes = G1.no_nodes + G2.no_nodes
+    G.no_edges = G1.no_edges + G2.no_edges
     return G, G1, G2
     
 if __name__ == "__main__":
@@ -81,4 +85,3 @@ if __name__ == "__main__":
     G.export(client_G)
     G1.export(client_G1)
     G2.export(client_G2)
-

--- a/graphs/kuzu/launcher.py
+++ b/graphs/kuzu/launcher.py
@@ -53,11 +53,13 @@ def test_count_star(max_iteration = 100, id = 0):
             continue
         try: res_G1 = client_G1.run(query).get_as_df().values.tolist()[0][0]
         except Exception as e:
+            msg = str(e)
             if "Parser exception" not in msg and "Binder exception" not in msg and "Interrupted" not in msg:
                 exceptions.append((query, msg))   
             continue
         try: res_G2 = client_G2.run(query).get_as_df().values.tolist()[0][0]
         except Exception as e:
+            msg = str(e)
             if "Parser exception" not in msg and "Binder exception" not in msg and "Interrupted" not in msg:
                 exceptions.append((query, msg))   
             continue
@@ -124,11 +126,13 @@ def test_count_star_2CC(max_iteration = 100, id = 0):
             continue
         try: res_G1 = client_G1.run(query).get_as_df().values.tolist()[0][0]
         except Exception as e:
+            msg = str(e)
             if "Parser exception" not in msg and "Binder exception" not in msg and "Interrupted" not in msg:
                 exceptions.append((query, msg))   
             continue
         try: res_G2 = client_G2.run(query).get_as_df().values.tolist()[0][0]
         except Exception as e:
+            msg = str(e)
             if "Parser exception" not in msg and "Binder exception" not in msg and "Interrupted" not in msg:
                 exceptions.append((query, msg))   
             continue

--- a/graphs/neo4j/algorithms/triangle_counting/triangle_counting.py
+++ b/graphs/neo4j/algorithms/triangle_counting/triangle_counting.py
@@ -41,6 +41,7 @@ class TestNeo4jTriangleCounting(Neo4jTester):
         for v in d_G1.keys():
             if d_G1[v] != d_G[v]: 
                 return False
+        return True
             
     def test(self):
         try:

--- a/graphs/neo4j/graph.py
+++ b/graphs/neo4j/graph.py
@@ -116,7 +116,6 @@ def neo4j_load_graph(G : BasicGraph, partition_arr,
 if __name__ == "__main__":
     basic_generator = BasicGenerator()
     basic_G, partition_arr = basic_generator.gen(6, 10)
-    G, G0, G1 = neo4j_load_graph(basic_G, partition_arr)
+    G, G0, G1, *_ = neo4j_load_graph(basic_G, partition_arr)
     print("OK")
-
 

--- a/graphs/networkx/entrance.py
+++ b/graphs/networkx/entrance.py
@@ -27,6 +27,9 @@ def time_limit(seconds):
 class Tester():
     def __init__(self):
         self.rules = {
+            "sum_smaller": sum_smaller,
+            "sum_equal": sum_equal,
+            "sum_greater": sum_greater,
             "node_dict_smaller" : node_dict_smaller, 
             "node_dict_equal" : node_dict_equal, 
             "node_dict_greater" : node_dict_greater, 
@@ -102,7 +105,7 @@ class Tester():
                             for G, G0, G1 in Graphs:
                                 try:
                                     passed, error_message = self.run_testcase(
-                                        target["algorithm"], G, G0, G1, target["rules"])
+                                        target["algorithm"], G, G0, G1, self.rules[target["rules"]])
                                 except:
                                     continue
                                 if not passed:

--- a/graphs/networkx/oracles.py
+++ b/graphs/networkx/oracles.py
@@ -1,8 +1,46 @@
+import math
+
+
+def _is_nan(value):
+    """Return whether value is a numeric NaN."""
+    try:
+        return math.isnan(value)
+    except TypeError:
+        return False
+
+
+def _node_dict_nan_error(G, G0, G1):
+    """Return an error message if a compared node result contains NaN."""
+    for result_name, subgraph_result in (("G0", G0), ("G1", G1)):
+        for node, subgraph_value in subgraph_result.items():
+            original_value = G[node]
+
+            if _is_nan(subgraph_value) or _is_nan(original_value):
+                return (
+                    f"NaN result for node {node}: "
+                    f"{result_name}[{node}] = {subgraph_value}, "
+                    f"G[{node}] = {original_value}"
+                )
+
+    return ""
+
+def _scalar_nan_error(G, G0, G1):
+    """Return an error message if a scalar result contains NaN."""
+    for result_name, value in (("G", G), ("G0", G0), ("G1", G1)):
+        if _is_nan(value):
+            return f"NaN result: {result_name} = {value}"
+
+    return ""
+
 
 def node_dict_smaller(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 < G
     """
+    error_msg = _node_dict_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     for v in G0.keys():
         if G0[v] - G[v] > eps:
             error_msg = "G0[" + str(v) + "] = " + str(G0[v]) + ", G[" + str(v) + "] = " + str(G[v])
@@ -17,6 +55,10 @@ def node_dict_equal(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 = G
     """
+    error_msg = _node_dict_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     for v in G0.keys():
         if abs(G0[v] - G[v]) > eps:
             error_msg = "G0[" + str(v) + "] = " + str(G0[v]) + ", G[" + str(v) + "] = " + str(G[v])
@@ -31,6 +73,10 @@ def node_dict_greater(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 > G
     """
+    error_msg = _node_dict_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     for v in G0.keys():
         if G0[v] - G[v] < -eps:
             error_msg = "G0[" + str(v) + "] = " + str(G0[v]) + ", G[" + str(v) + "] = " + str(G[v])
@@ -45,6 +91,10 @@ def value_smaller(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 > G
     """
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     if G0 - G > eps:
         error_msg = "G0 = " + str(G0) + ", G = " + str(G)
         return False, error_msg
@@ -59,6 +109,10 @@ def value_equal(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 > G
     """
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     if abs(G0 - G) > eps:
         error_msg = "G0 = " + str(G0) + ", G = " + str(G)
         return False, error_msg
@@ -73,6 +127,10 @@ def value_greater(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 > G
     """
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     if G0 - G < -eps:
         error_msg = "G0 = " + str(G0) + ", G = " + str(G)
         return False, error_msg
@@ -87,6 +145,10 @@ def sum_greater(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 + G1 > G
     """
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     if G0 + G1 - G < -eps:
         error_msg = "G0 + G1 = " + str(G0 + G1) + ", G = " + str(G)
         return False, error_msg
@@ -101,7 +163,11 @@ def sum_smaller(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 + G1 > G
     """
-    if G0 + G1 - G > -eps:
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
+    if G0 + G1 - G > eps:
         error_msg = "G0 + G1 = " + str(G0 + G1) + ", G = " + str(G)
         return False, error_msg
     
@@ -115,6 +181,10 @@ def sum_equal(G, G0, G1, eps = 1e-2):
     """Validates the algorithms that return a dictionary of nodes.
     Using G0 + G1 > G
     """
+    error_msg = _scalar_nan_error(G, G0, G1)
+    if error_msg:
+        return False, error_msg
+
     if abs(G0 + G1 - G) > eps:
         error_msg = "G0 + G1 = " + str(G0 + G1) + ", G = " + str(G)
         return False, error_msg


### PR DESCRIPTION
## Summary

This PR fixes several correctness and robustness issues found while reproducing the GSlicer experiments across NetworkX, Neo4j, and Kuzu.

### NetworkX

- Register the three `sum_*` oracle functions in `Tester.rules`.
- Resolve oracle names to callable functions before executing test cases.
- Reject `NaN` results explicitly instead of allowing comparisons with `NaN` to pass silently.
- Fix the epsilon condition in `sum_smaller`.

### Neo4j

- Prevent the graph generator from selecting a node ID outside the valid range.
- Update the graph-loading example to handle all values returned by `neo4j_load_graph`.
- Return `True` explicitly when triangle-counting validation succeeds.

### Kuzu

- Disable replacement when selecting nodes for a partition.
- Correct the node and edge metadata calculations in `partition_2CC`.
- Capture the current exception message when queries on G1 or G2 fail.

## Validation

Tested with:

- Python 3.10.20
- NetworkX 3.1
- Neo4j 5.10.0 with GDS 2.4.2
- Kuzu 0.4.2

Validation performed:

- Python compilation checks for all modified files
- Numeric and `NaN` oracle regression checks
- Neo4j loading and triangle-counting checks
- Kuzu graph generation, partitioning, loading, and metadata checks
- Whitespace validation with `git diff --check`